### PR TITLE
Fix for use with ajax post

### DIFF
--- a/Jsoneditor.php
+++ b/Jsoneditor.php
@@ -41,10 +41,14 @@ class Jsoneditor extends InputWidget
         $view = $this->getView();
         JsoneditorAsset::register($view);
         $editorName = BaseInflector::camelize($this->id) . 'Editor';
+        // Add possible user defined change function to ActiveField update method
+        $this->editorOptions->change = "function() {
+                jQuery('#" . $this->id . "').val(" . $editorName . ".getText());" . 
+                (isset($this->editorOptions->change)?$this->editorOptions->change:'') . "
+            };";
         $view->registerJs(
             "var container = document.getElementById('" . $this->options['id'] . "');
             var options = " . Json::encode($this->editorOptions). ";
-            options.change = function() {jQuery('#" . $this->id . "').val(" . $editorName . ".getText());};
             var json = " . $this->value . ";
             " . $editorName . " = new JSONEditor(container, options, json);"
         );

--- a/Jsoneditor.php
+++ b/Jsoneditor.php
@@ -5,6 +5,7 @@ namespace devgroup\jsoneditor;
 use yii\helpers\BaseInflector;
 use yii\helpers\Html;
 use yii\helpers\Json;
+use yii\web\JsExpression;
 use yii\widgets\InputWidget;
 
 class Jsoneditor extends InputWidget
@@ -42,10 +43,12 @@ class Jsoneditor extends InputWidget
         JsoneditorAsset::register($view);
         $editorName = BaseInflector::camelize($this->id) . 'Editor';
         // Add possible user defined change function to ActiveField update method
-        $this->editorOptions->change = "function() {
-                jQuery('#" . $this->id . "').val(" . $editorName . ".getText());" . 
-                (isset($this->editorOptions->change)?$this->editorOptions->change:'') . "
-            };";
+        $this->editorOptions['change'] = new JsExpression(
+            "function() {".
+            "jQuery('#" . $this->id . "').val(" . $editorName . ".getText());" .
+            (isset($this->editorOptions['change'])?$this->editorOptions['change']:'') .
+            "}"
+        );
         $view->registerJs(
             "var container = document.getElementById('" . $this->options['id'] . "');
             var options = " . Json::encode($this->editorOptions). ";

--- a/Jsoneditor.php
+++ b/Jsoneditor.php
@@ -43,13 +43,10 @@ class Jsoneditor extends InputWidget
         $editorName = BaseInflector::camelize($this->id) . 'Editor';
         $view->registerJs(
             "var container = document.getElementById('" . $this->options['id'] . "');
-            var options = " . Json::encode($this->editorOptions) . ";
+            var options = " . Json::encode($this->editorOptions). ";
+            options.change = function() {jQuery('#" . $this->id . "').val(" . $editorName . ".getText());};
             var json = " . $this->value . ";
-            " . $editorName . " = new JSONEditor(container, options, json);
-            jQuery('#" . $this->id . "').parents('form').eq(0).submit(function() {
-                jQuery('#" . $this->id . "').val(" . $editorName . ".getText());
-                return true;
-            });"
+            " . $editorName . " = new JSONEditor(container, options, json);"
         );
         echo Html::hiddenInput($this->name, $this->value, ['id' => $this->id]);
         echo Html::tag('div', '', $this->options);


### PR DESCRIPTION
Hidden ActiveField is being updated on every change making validation instant and fix use with ajax post where current used form submit is handled by ajax post routine.

This solution allows for any other Javascript to be attached to on change by encapsulation it.
